### PR TITLE
Fix range gotcha getting a pointer to an element

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -137,12 +137,14 @@ func createScanTargetGroup(targetsFile, checktypesFile string) (*client.ScanTarg
 
 	cts := []*client.ScanChecktype{}
 	for _, c := range checktypes {
+		c := c
 		ct := client.ScanChecktype{Name: &c.Name, Options: &c.DefaultOptions}
 		cts = append(cts, &ct)
 	}
 
 	targetsG := []*client.Target{}
 	for _, a := range assets {
+		a := a
 		t := client.Target{
 			Identifier: &a.target,
 			Type:       &a.assetType,


### PR DESCRIPTION
The address of the element assigned in the range will be the
same in all the iterations of the array, so using a pointer to it inside
the loop will make the pointed value to be the last assigned value in
all the iterations.

Creating a copy of the element inside the array fixes the issue as now
we have a new structure in every iteration.