### PR TITLE
Fix command line help messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func Execute() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&scheme, "scheme", "s", "https", "scheme of the vulcan-persistence endpoint")
-	RootCmd.PersistentFlags().StringVarP(&host, "Host", "H", "127.0.0.1", "vulcan-persistence endpoint")
+	RootCmd.PersistentFlags().StringVarP(&scheme, "scheme", "s", "https", "scheme of the vulcan-scan-engine endpoint")
+	RootCmd.PersistentFlags().StringVarP(&host, "Host", "H", "127.0.0.1", "vulcan-scan-engine endpoint")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "prints verbose information during command execution")
 }


### PR DESCRIPTION
This PR just fixes a couple of "leftovers" in the command line help strings. We forgot to update them when we moved the functionality from the vulcan-persistence to the vulcan-scan-engine.